### PR TITLE
Fix: db config for test

### DIFF
--- a/minerva/minerva/settings.py
+++ b/minerva/minerva/settings.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 import os
-import dj_database_url
 import environ
+import sys
 
 # Initialise environment variables
 env = environ.Env()
@@ -103,6 +103,11 @@ DATABASES = {
     }
 }
 
+if "test" in sys.argv or "test_coverage" in sys.argv:
+    DATABASES["default"] = {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": ":memory:",
+    }
 
 AUTH_PASSWORD_VALIDATORS = [
     {


### PR DESCRIPTION
Configuración de SQLite para pruebas debido a restricciones en el plan gratuito de Clever Cloud. En este plan, no se permiten operaciones de creación y destrucción de bases de datos para los tests. Se implementa una solución temporal que utiliza SQLite como base de datos predeterminada en los tests. La API está desplegada en Render con la BD PostgreSQL alojado en Clever Cloud.